### PR TITLE
feat: add callable workflows

### DIFF
--- a/.github/workflows/__call-release-setup.yml
+++ b/.github/workflows/__call-release-setup.yml
@@ -1,0 +1,72 @@
+---
+# This workflow is designed to be called by other workflows to set up a release easily.
+
+name: Release Setup
+permissions:
+  contents: write  # read does not work to check squash and merge details
+
+on:
+  workflow_call:
+    inputs:
+      dotnet:
+        description: "Whether to create a dotnet version (4 components, e.g. yyyy.mmdd.hhmm.ss)."
+        default: 'false'
+        required: false
+        type: string
+      include_tag_prefix_in_output:
+        description: "Whether to include the tag prefix in the output."
+        default: 'true'
+        required: false
+        type: string
+      tag_prefix:
+        description: "The tag prefix. This will be used when searching for existing releases in GitHub API."
+        default: "v"
+        required: false
+        type: string
+    outputs:
+      publish_release:
+        description: "Whether to publish a release."
+        value: ${{ jobs.release-setup.outputs.publish_release }}
+      release_body:
+        description: "The body for the release."
+        value: ${{ jobs.release-setup.outputs.release_body }}
+      release_commit:
+        description: "The commit hash for the release."
+        value: ${{ jobs.release-setup.outputs.release_commit }}
+      release_generate_release_notes:
+        description: "Whether to generate release notes for the release. (Always `true`)"
+        value: ${{ jobs.release-setup.outputs.release_generate_release_notes }}
+      release_tag:
+        description: "The tag for the release (i.e. `release_version` with prefix)"
+        value: ${{ jobs.release-setup.outputs.release_tag }}
+      release_version:
+        description: "The version for the release (i.e. `yyyy.mmdd.hhmmss`)"
+        value: ${{ jobs.release-setup.outputs.release_version }}
+    secrets:
+      GH_TOKEN:
+        description: "GitHub token to use for API requests."
+        required: true
+
+jobs:
+  release-setup:
+    name: Release Setup
+    outputs:
+      publish_release: ${{ steps.release-setup.outputs.publish_release }}
+      release_body: ${{ steps.release-setup.outputs.release_body }}
+      release_commit: ${{ steps.release-setup.outputs.release_commit }}
+      release_generate_release_notes: ${{ steps.release-setup.outputs.release_generate_release_notes }}
+      release_tag: ${{ steps.release-setup.outputs.release_tag }}
+      release_version: ${{ steps.release-setup.outputs.release_version }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Release Setup
+        id: release-setup
+        uses: LizardByte/actions/actions/release_setup@master
+        with:
+          dotnet: ${{ inputs.dotnet || 'false' }}
+          github_token: ${{ secrets.GH_TOKEN }}
+          include_tag_prefix_in_output: ${{ inputs.include_tag_prefix_in_output || 'true' }}
+          tag_prefix: ${{ inputs.tag_prefix || 'v' }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The goal of this PR was to add callable workflows that would simplify using the actions in a separate job so that outputs don't have to be defined in that job specifically... however this concept won't work well as it's not easy to specify which version of the action to use in the called workflow. We would ideally want to use the same version as the caller workflow specified, but so far I don't think that is possible without some crazy hacks. This will be closed for now.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
