### PR TITLE
fix(release_create): remove extra blank line on virustotal amended release notes

### DIFF
--- a/actions/release_create/action.yml
+++ b/actions/release_create/action.yml
@@ -89,13 +89,13 @@ runs:
 
         # If we have VT results, append them
         if [ -n '${{ steps.vt.outputs.json }}' ]; then
-          # Add separator if body exists and isn't empty
-          if [ -s ${rb_file} ] && [ "$(cat ${rb_file} | tr -d '[:space:]')" != "" ]; then
-            echo "" >> ${rb_file}
-          fi
-
           # Check if VirusTotal Results header already exists, if not add it
           if ! grep -qF "$VT_HEADER" ${rb_file}; then
+            # Add separator if body exists and isn't empty
+            if [ -s ${rb_file} ] && [ "$(cat ${rb_file} | tr -d '[:space:]')" != "" ]; then
+              echo "" >> ${rb_file}
+            fi
+
             echo "---" >> ${rb_file}
             echo "$VT_HEADER" >> ${rb_file}
           fi


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Amending virustotal results would result in an empty line inserted between the old and new results. This would make the list of results look funny, with an extra space between every list item.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
