### PR TITLE
harden: fix security issue in action.yml

### DIFF
--- a/actions/release_homebrew/action.yml
+++ b/actions/release_homebrew/action.yml
@@ -165,7 +165,7 @@ runs:
 
     - name: Setup Homebrew
       id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@main
+      uses: Homebrew/actions/setup-homebrew@6373c73b318da78d7a3457597e6cc3b6526cbd59  # main
       with:
         stable: true
 


### PR DESCRIPTION
## Summary
Harden input handling in `actions/release_homebrew/action.yml` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag` |
| **File** | `actions/release_homebrew/action.yml:168` |
| **Assessment** | Defensive hardening |

**Description**: GitHub Actions step uses a mutable tag or branch reference. Tags and branch names can be silently repointed by the action owner, enabling supply-chain attacks — as seen in the trivy-action and kics-github-action compromises. Pin the reference to a full 40-character commit SHA instead, e.g. `uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608`.

## Changes
- `actions/release_homebrew/action.yml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag scanner=semgrep -->
